### PR TITLE
[MAISTRA-801] Add SMCP and SMMR to the output

### DIFF
--- a/gather_istio
+++ b/gather_istio
@@ -68,6 +68,12 @@ function getCRDs() {
     result+=" ${crd} "
   done
 
+  # Get the remaining CRD's that don't contain a maistra label. See https://issues.jboss.org/browse/MAISTRA-799
+  local output=$(oc get crd -l'!maistra-version' -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -E 'maistra|istio')
+  for crd in ${output}; do
+    result+=" ${crd} "
+  done
+
   echo ${result}
 }
 


### PR DESCRIPTION
Currently they are not part of the output because the
must-gather script is relying on the maistra-version label
to get the list of CRD's. Those two CRD's don't contain that label.