### PR TITLE
[Maistra-841] Update to use the namespace that the operator is actually deployed in

### DIFF
--- a/gather_istio
+++ b/gather_istio
@@ -76,7 +76,9 @@ function main() {
   echo "Executing Istio gather script"
   echo
 
-  local resources="ns/istio-operator MutatingWebhookConfiguration ValidatingWebhookConfiguration"
+  operatorNamespace=$(oc get pods --all-namespaces -l name=istio-operator -o jsonpath="{.items[0].metadata.namespace}")
+  local resources="ns/${operatorNamespace} MutatingWebhookConfiguration ValidatingWebhookConfiguration"
+
 
   local controlPlanes="$(getControlPlanes)"
   resources+="$(addResourcePrefix ns ${controlPlanes})"


### PR DESCRIPTION
Without this PR, we look in istio-operator only. Under OLM, the operator deploys to openshift-operators by default, but that is not guaranteed. As a side effect of this (assuming that Kiali and Jaeger are also deployed to openshift-operators), we also collect Jaeger and Kiali for free. Also tested the templates as part of this, and that gets dumped to core/configmap as well.