### PR TITLE
[MAISTRA-2068] Fix must-gather 2 to collect logs for both 2.0 and 1.0 control planes

### DIFF
--- a/gather_istio
+++ b/gather_istio
@@ -89,12 +89,7 @@ function getCRDs() {
 function getPilotName() {
   local namespace="${1}"
 
-  #this will pipe stderr to stdout. In the case where istiod fails and pilot succeeds, the correct one will be picked up. In the case where both return an error, then the error is returned
-  pilotName=$(oc get pods -n ${namespace} -lapp=istiod  -o jsonpath="{.items[0].metadata.name}" 2>&1)
-  if [ $? == 1 ]; then
-    pilotName=$(oc get pods -n ${namespace} -lapp=pilot  -o jsonpath="{.items[0].metadata.name}" 2>&1)
-  fi
-  echo ${pilotName}
+  oc get pods -n ${namespace} -l 'app in (istiod,pilot)'  -o jsonpath="{.items[0].metadata.name}"
 }
 
 # getSynchronization dumps the synchronization status for the specified control plane

--- a/gather_istio
+++ b/gather_istio
@@ -85,6 +85,18 @@ function getCRDs() {
   echo ${result}
 }
 
+# getPilotName gets the name of the Pilot instance in that namespace. 
+function getPilotName() {
+  local namespace="${1}"
+
+  #this will pipe stderr to stdout. In the case where istiod fails and pilot succeeds, the correct one will be picked up. In the case where both return an error, then the error is returned
+  pilotName=$(oc get pods -n ${namespace} -lapp=istiod  -o jsonpath="{.items[0].metadata.name}" 2>&1)
+  if [ $? == 1 ]; then
+    pilotName=$(oc get pods -n ${namespace} -lapp=pilot  -o jsonpath="{.items[0].metadata.name}" 2>&1)
+  fi
+  echo ${pilotName}
+}
+
 # getSynchronization dumps the synchronization status for the specified control plane
 # to a file in the control plane directory of the control plane namespace
 # Arguments:
@@ -95,7 +107,7 @@ function getSynchronization() {
   local namespace="${1}"
 
   echo "Collecting resources for namespace ${cp}"
-  local pilotName=$(oc get pods -n ${namespace} -lapp=istiod  -o jsonpath="{.items[0].metadata.name}")
+  local pilotName=$(getPilotName ${namespace})
 
   echo "Overall Envoy synchronization status for namespace ${namespace}" 2>&1 1>${logPath}/controlPlaneStatus
   local logPath=${BASE_COLLECTION_PATH}/namespaces/${namespace}/controlplane
@@ -112,7 +124,7 @@ function getSynchronization() {
 #   nothing
 function getEnvoyConfigForPodsInNamespace() {
   local controlPlaneNamespace="${1}"
-  local pilotName=$(oc get pods -n ${controlPlaneNamespace} -lapp=istiod  -o jsonpath="{.items[0].metadata.name}")
+  local pilotName=$(getPilotName ${controlPlaneNamespace})
   local podNamespace="${2}"
 
   echo "Collecting Envoy config for pods in ${podNamespace}, control plane namespace ${controlPlaneNamespace}"


### PR DESCRIPTION
This updates must-gather to collect both data for 1.0 and 2.0 control planes. To do this, it attempts to get the istiod pilot name first and then if the error code is non-zero, it collects the 1.0 pilot name. If neither return successful, the error fro pilot is logged.