### PR TITLE
MAISTRA-2276, pulling in the following change

### DIFF
--- a/gather_istio
+++ b/gather_istio
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MUST_GATHER=${MUST_GATHER:-/usr/bin/openshift-must-gather}
 BASE_COLLECTION_PATH="/must-gather"
 
 # The following CRDs are not managed by the Maistra operator but it
@@ -148,7 +147,7 @@ function main() {
       resources+="$(addResourcePrefix ns ${members})"
       getSynchronization ${cp}
       for cr in ${DEPENDENCY_CRS}; do
-        ${MUST_GATHER} inspect -n ${cp} ${cr}
+        oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" -n ${cp} ${cr}
       done
 
        #collect Envoy configuration first from control plane pods and then from members
@@ -165,14 +164,14 @@ function main() {
   for resource in ${resources}; do
     echo
     echo "Dumping resource ${resource}..."
-    ${MUST_GATHER} inspect ${resource}
+    oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" ${resource}
   done
 
   # Get all CRD's
   for crd in ${crds}; do
     echo
     echo "Dumping CRD ${crd}..."
-    ${MUST_GATHER} inspect --all-namespaces ${crd}
+    oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" --all-namespaces ${crd}
   done
 
   echo


### PR DESCRIPTION
    MAISTRA-1684: Fix the gather script

    Replace the old, deprecated `openshift-must-gather` with `oc adm inspect`
    and set its output to the right location.