### PR TITLE
Add executable perm. via the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,7 @@ RUN mv /usr/bin/gather /usr/bin/gather_original
 # Use our gather script in place of the original one
 COPY gather_istio.sh /usr/bin/gather
 
+# Make it executable
+RUN chmod +x /usr/bin/gather
+
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
It is generally best practice to explicitly set the executable permission for the script in the Dockerfile, rather than relying on the chmod command to do it when the container is run. This improves the reliability of the image:

1. It makes sense to explicitly set the executable permission for a script in the Dockerfile (even if the script already has executable permissions). This is because the executable permission can be lost when the script is copied into the Docker image during the build process.

2. By explicitly setting the executable permission in the Dockerfile, you can ensure that the script has the correct permissions when the image is built, and that it will be executable when the container is run.

3. Additionally, explicitly setting the executable permission in the Dockerfile makes it clear to anyone looking at the Dockerfile that the script is intended to be executable, which can be helpful for understanding how the image is meant to be used.