### PR TITLE
OSSM-2435 Report error if specified namespace is not a control plane namespace

### DIFF
--- a/gather_istio.sh
+++ b/gather_istio.sh
@@ -168,7 +168,12 @@ function main() {
   resources+="$(addResourcePrefix ns "${controlPlanes}")"
 
   for cp in ${controlPlanes}; do
-      echo "Processing control plane ${cp}"
+      if [[ -z $(oc get smcp -n "${cp}" -oname) ]]; then
+        echo "ERROR: namespace ${cp} does not contain a ServiceMeshControlPlane object"
+        exit 1
+      fi
+
+      echo "Processing control plane namespace: ${cp}"
 
       local members
       members=$(getMembers "${cp}")


### PR DESCRIPTION
This ensures that users are notified if they run must-gather against a member namespace or if they run it against any other namespace other than a valid control plane namespace (one that contains a ServiceMeshControlPlane object).