### PR TITLE
OSSM-2429 Ensure only specified namespaces are captured

### DIFF
--- a/gather_istio.sh
+++ b/gather_istio.sh
@@ -125,6 +125,7 @@ function getEnvoyConfigForPodsInNamespace() {
   pilotName=$(getPilotName "${controlPlaneNamespace}")
   local podNamespace="${2}"
 
+  echo
   echo "Collecting Envoy config for pods in ${podNamespace}, control plane namespace ${controlPlaneNamespace}"
 
   local pods
@@ -167,16 +168,16 @@ function inspect() {
 
   echo
   if [ -n "$ns" ]; then
-    echo "Inspecting resource ${resource} in namespace ${ns}..."
+    echo "Inspecting resource ${resource} in namespace ${ns}"
     oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" "${resource}" -n "${ns}"
   else
-    echo "Inspecting resource ${resource}..."
+    echo "Inspecting resource ${resource}"
     oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" "${resource}"
   fi
 }
 
 function main() {
-  local crds controlPlanes members
+  local crds controlPlanes members smcpName
   echo
   echo "Executing Istio gather script"
   echo
@@ -188,8 +189,8 @@ function main() {
   operatorNamespace=$(oc get pods --all-namespaces -l name=istio-operator -o jsonpath="{.items[0].metadata.namespace}")
 
   inspect "ns/${operatorNamespace}"
-  inspect MutatingWebhookConfiguration
-  inspect ValidatingWebhookConfiguration
+  inspect "mutatingwebhookconfiguration/${operatorNamespace}.servicemesh-resources.maistra.io"
+  inspect "validatingwebhookconfiguration/${operatorNamespace}.servicemesh-resources.maistra.io"
 
   crds="$(getCRDs)"
   for crd in ${crds}; do
@@ -204,17 +205,22 @@ function main() {
   inspect clusterserviceversion "${operatorNamespace}"
 
   for cp in ${controlPlanes}; do
-      if [[ -z $(oc get smcp -n "${cp}" -oname) ]]; then
+      smcpName="$(oc get smcp -n "${cp}" -o jsonpath='{.items[*].metadata.name}')"
+      if [[ -z "$smcpName" ]]; then
         echo "ERROR: namespace ${cp} does not contain a ServiceMeshControlPlane object"
         exit 1
       fi
 
+      echo
       echo "Processing control plane namespace: ${cp}"
 
       inspect "ns/${cp}"
       for crd in ${crds}; do
         inspect "${crd}" "${cp}"
       done
+
+      inspect "mutatingwebhookconfiguration/istiod-${smcpName}-${cp}"
+      inspect "validatingwebhookconfiguration/istio-validator-${smcpName}-${cp}"
 
       getEnvoyConfigForPodsInNamespace "${cp}" "${cp}"
       getSynchronization "${cp}"


### PR DESCRIPTION
Before this change, gather_istio.sh captured all the validating/mutating webhook configurations, not just those related to OSSM. When capturing these resources, the associated namespaces are automatically captured by `oc adm inspect`. This caused unexpected namespaces to appear in the must-gather.

In this commit, we ensure that we capture only those validating/mutating webhook configurations that are related to the control plane specified in the `oc adm must-gather` command, thereby ensuring that only the specified namespaces are captured.