### PR TITLE
OSSM-6814:  Update to collect new validating/mutating webhook conf

### DIFF
--- a/gather_istio.sh
+++ b/gather_istio.sh
@@ -177,8 +177,16 @@ function main() {
 
   operatorNamespace=$(oc get pods --all-namespaces -l name=istio-operator -o jsonpath="{.items[0].metadata.namespace}")
 
-  inspect "mutatingwebhookconfiguration/${operatorNamespace}.servicemesh-resources.maistra.io"
-  inspect "validatingwebhookconfiguration/${operatorNamespace}.servicemesh-resources.maistra.io"
+  validatingwebhookconfigurations=$(oc get validatingwebhookconfiguration -o custom-columns=NAME:.metadata.name | grep maistra)
+  for validatingwebhookconfiguration in $validatingwebhookconfigurations; do
+    inspect "validatingwebhookconfiguration/$validatingwebhookconfiguration"
+  done
+
+  mutatingwebhookconfigurations=$(oc get mutatingwebhookconfiguration -o custom-columns=NAME:.metadata.name | grep maistra)
+  for mutatingwebhookconfiguration in $mutatingwebhookconfigurations; do
+    inspect "mutatingwebhookconfiguration/$mutatingwebhookconfiguration"
+  done
+
   inspect nodes
 
   for r in $(oc get clusterroles,clusterrolebindings -l maistra-version,maistra.io/owner= -oname); do


### PR DESCRIPTION
1. Pushed to quay as quay.io/maistra/istio-must-gather:2.6.0
2. Tested with image above and mtt (https://github.com/maistra/maistra-test-tool/pull/709) 
```
    smcp_must_gather_test.go:112: STEP 3: Verify cluster-scoped-resources files exist in cluster-scoped-resources folder
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterrolebindings/istiod-internal-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/istiod-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/istio-validator-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/istiod-clusterrole-basic-istio-system.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smmr.validation.maistra.io-nbnmn.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smm.validation.maistra.io-4lct9.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/smcp.mutation.maistra.io-2c7wr.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/mutatingwebhookconfigurations/smmr.mutation.maistra.io-lqjdn.yaml exists
    smcp_must_gather_test.go:182:    SUCCESS: /tmp/must-gather-1670015299/**/cluster-scoped-resources/admissionregistration.k8s.io/validatingwebhookconfigurations/smcp.validation.maistra.io-jm4x4.yaml exists
```

Related:

1. https://issues.redhat.com/browse/OSSM-6814
2. https://github.com/maistra/maistra-test-tool/pull/708
3. https://github.com/maistra/istio-operator/commit/a33d372e098dc22319da45f7da4002cdba7252ee
4. Jenkins mtt run 2219 :green_circle: 
